### PR TITLE
Validate config after load.

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -125,3 +125,16 @@ bool isHWLightingAllowed()
 		return false;
 	return GBI.isHWLSupported();
 }
+
+void Config::validate()
+{
+	if (frameBufferEmulation.enable != 0 && frameBufferEmulation.N64DepthCompare != 0)
+		video.multisampling = 0;
+	if (frameBufferEmulation.nativeResFactor == 1) {
+		generalEmulation.enableNativeResTexrects = 0;
+		generalEmulation.correctTexrectCoords = tcDisable;
+	} else {
+		if (generalEmulation.enableNativeResTexrects != 0)
+			generalEmulation.correctTexrectCoords = tcDisable;
+	}
+}

--- a/src/Config.h
+++ b/src/Config.h
@@ -179,6 +179,7 @@ struct Config
 	} debug;
 
 	void resetToDefaults();
+	void validate();
 };
 
 #define hack_Ogre64					(1<<0)  //Ogre Battle 64 background copy

--- a/src/mupenplus/Config_mupenplus.cpp
+++ b/src/mupenplus/Config_mupenplus.cpp
@@ -441,4 +441,6 @@ void Config_LoadConfig()
 
 	if (config.generalEmulation.enableCustomSettings)
 		Config_LoadCustomConfig();
+
+	config.validate();
 }

--- a/src/windows/Config_windows.cpp
+++ b/src/windows/Config_windows.cpp
@@ -18,6 +18,7 @@ void Config_DoConfig(/*HWND hParent*/)
 	const bool bRestart = RunConfig(strIniFolderPath, api().isRomOpen() ? RSP.romname : nullptr);
 	if (config.generalEmulation.enableCustomSettings != 0)
 		LoadCustomRomSettings(strIniFolderPath, RSP.romname);
+	config.validate();
 	if (bRestart)
 		dwnd().restart();
 	ConfigOpen = false;
@@ -30,4 +31,5 @@ void Config_LoadConfig()
 	LoadConfig(strIniFolderPath);
 	if (config.generalEmulation.enableCustomSettings != 0)
 		LoadCustomRomSettings(strIniFolderPath, RSP.romname);
+	config.validate();
 }


### PR DESCRIPTION
Fixed glitches when 'MSAA' and 'N64 depth compare' both enabled, #1815